### PR TITLE
note 追加するときに更新するチケットのタイトルを表示するようにした

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -208,3 +208,7 @@ func (c *client) DeleteIssue(id int) error {
 	}
 	return err
 }
+
+func (issue *Issue) GetTitle() string {
+	return issue.Tracker.Name + " #" + strconv.Itoa(issue.Id) + ": " + issue.Subject
+}


### PR DESCRIPTION
note 書くとき間違ったチケットに追加しようとしてないか怖かったのでタイトルを表示するように修正しました．表示は redmine の タイトルタグを参考にしてます．

fmt の位置が変わってるのは go fmt したせいです．
