### PR TITLE
自己署名証明書の redmine に接続ができるようにする

### DIFF
--- a/godmine/main.go
+++ b/godmine/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -8,6 +9,7 @@ import (
 	"github.com/mattn/go-redmine"
 	"io/ioutil"
 	"math/rand"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,6 +23,7 @@ type config struct {
 	Apikey   string `json:"apikey"`
 	Project  int    `json:"project"`
 	Editor   string `json:"editor"`
+	Insecure bool   `json:"insecure"`
 }
 
 var profile *string = flag.String("p", os.Getenv("GODMINE_ENV"), "profile")
@@ -642,6 +645,13 @@ func main() {
 		usage()
 	}
 	conf = getConfig()
+	if conf.Insecure {
+		http.DefaultClient = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		}
+	}
 
 	switch flag.Arg(0) {
 	case "i", "issue":


### PR DESCRIPTION
自分で使いたい環境が自己署名証明書のものがあったので追加しました．

dev ブランチで http パッケージをclient.go にまとめるようにしてるのは確認してますが最終的にどうなるかちょっとわからなかったので，とりあえず main.go の中で http.DefaultClient を上書きする処理を追加して master に pull request しておきます．
