### PR TITLE
同時に複数のチケットを編集できるようにする

### DIFF
--- a/godmine/main.go
+++ b/godmine/main.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type config struct {
@@ -637,6 +638,7 @@ User Commands:
 }
 
 func main() {
+	rand.Seed(time.Now().UnixNano())
 	flag.Parse()
 	if flag.NArg() <= 1 {
 		usage()


### PR DESCRIPTION
チケット編集時のファイル名に rand.Int() を使ってますが，これが一定の値を返さないようにして複数のチケットを同時に編集できるようにしました．

参考
http://ideone.com/po0M6j
