### PR TITLE
Change "assigned" field of Issues to "assigned_to"

### DIFF
--- a/godmine/main.go
+++ b/godmine/main.go
@@ -334,8 +334,8 @@ func showIssue(id int) {
 		fatal("Failed to show issue: %s\n", err)
 	}
 	assigned := ""
-	if issue.Assigned != nil {
-		assigned = issue.Assigned.Name
+	if issue.AssignedTo != nil {
+		assigned = issue.AssignedTo.Name
 	}
 
 	fmt.Printf(`

--- a/issue.go
+++ b/issue.go
@@ -31,7 +31,7 @@ type Issue struct {
 	Status      *IdName `json:"status"`
 	Priority    *IdName `json:"priority"`
 	Author      *IdName `json:"author"`
-	Assigned    *IdName `json:"assigned"`
+	Assigned    *IdName `json:"assigned_to"`
 	Notes       string  `json:"notes"`
 	StatusDate  string  `json:"status_date"`
 	CreatedOn   string  `json:"created_on"`

--- a/issue.go
+++ b/issue.go
@@ -31,7 +31,7 @@ type Issue struct {
 	Status      *IdName `json:"status"`
 	Priority    *IdName `json:"priority"`
 	Author      *IdName `json:"author"`
-	Assigned    *IdName `json:"assigned_to"`
+	AssignedTo  *IdName `json:"assigned_to"`
 	Notes       string  `json:"notes"`
 	StatusDate  string  `json:"status_date"`
 	CreatedOn   string  `json:"created_on"`


### PR DESCRIPTION
Though I don't think there is published full specification of Issue resource, it seems that Redmine returns Issue with `"assigned_to"` field, not `"assigned"`.

- Source: http://www.redmine.org/projects/redmine/repository/entry/trunk/app/views/issues/show.api.rsb
- Python impl: https://github.com/maxtepkeev/python-redmine/blob/master/redmine/resources.py

\# Should I also rename `Issue.Assigned` field to `Issue.AssignedTo`?