### PR TITLE
Fix issue creation with nil custom_fields

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -21,28 +21,28 @@ type issuesResult struct {
 }
 
 type Issue struct {
-	Id          int     `json:"id"`
-	Subject     string  `json:"subject"`
-	Description string  `json:"description"`
-	ProjectId   int     `json:"project_id"`
-	Project     *IdName `json:"project"`
-	Tracker     *IdName `json:"tracker"`
-	StatusId    int     `json:"status_id"`
-	Status      *IdName `json:"status"`
-	Priority    *IdName `json:"priority"`
-	Author      *IdName `json:"author"`
-	AssignedTo  *IdName `json:"assigned_to"`
-	Notes       string  `json:"notes"`
-	StatusDate  string  `json:"status_date"`
-	CreatedOn   string  `json:"created_on"`
-	UpdatedOn   string  `json:"updated_on"`
-	CustomFields []*CustomField `json:"custom_fields"`
+	Id           int            `json:"id"`
+	Subject      string         `json:"subject"`
+	Description  string         `json:"description"`
+	ProjectId    int            `json:"project_id"`
+	Project      *IdName        `json:"project"`
+	Tracker      *IdName        `json:"tracker"`
+	StatusId     int            `json:"status_id"`
+	Status       *IdName        `json:"status"`
+	Priority     *IdName        `json:"priority"`
+	Author       *IdName        `json:"author"`
+	AssignedTo   *IdName        `json:"assigned_to"`
+	Notes        string         `json:"notes"`
+	StatusDate   string         `json:"status_date"`
+	CreatedOn    string         `json:"created_on"`
+	UpdatedOn    string         `json:"updated_on"`
+	CustomFields []*CustomField `json:"custom_fields,omitempty"`
 }
 
 type CustomField struct {
-	Id      int     `json:"id"`
-	Name	string  `json:"name"`
-	Value	string  `json:"value"`
+	Id    int    `json:"id"`
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 func (c *client) IssuesOf(projectId int) ([]Issue, error) {


### PR DESCRIPTION
Trying to create an issue using the lib with the following code :

``` go
var issue redmine.Issue

issue.ProjectId = 1
issue.Subject = "Subject"
issue.Description = "Description"

c := redmine.NewClient(endpoint, apikey)
_, err := c.CreateIssue(issue) 
```
Redmine returns an error 500 and there's en entry in the log :
```
NoMethodError (undefined method `inject' for nil:NilClass):
  lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb:54:in `custom_fields='
  app/models/issue.rb:358:in `assign_attributes_with_project_and_tracker_first'
  app/models/issue.rb:483:in `safe_attributes='
  app/controllers/issues_controller.rb:444:in `build_new_issue_from_params'
```

The problem is that the custom_fields key must not be in the JSON if its value is nil or empty.

I've only added the tag omitempty to the custom_fields attribute so it's not added in the JSON if its value is empty
