### PR TITLE
Fix issue with resetting parent issue.

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -232,6 +232,32 @@ func (issue *Issue) GetTitle() string {
 	return issue.Tracker.Name + " #" + strconv.Itoa(issue.Id) + ": " + issue.Subject
 }
 
+// MarshalJSON marshals issue to JSON.
+// This overrides the default MarshalJSON() to reset parent issue.
+func (issue Issue) MarshalJSON() ([]byte, error) {
+	type Issue2 Issue
+
+	// To reset parent issue, set empty string to "parent_issue_id"
+	var parentIssueID *string
+	if issue.Parent == nil {
+		// reset parent issue
+		id := ""
+		parentIssueID = &id
+	} else if issue.ParentId > 0 {
+		// set parent issue
+		id := strconv.Itoa(issue.ParentId)
+		parentIssueID = &id
+	}
+
+	return json.Marshal(&struct {
+		Issue2
+		ParentId *string `json:"parent_issue_id,omitempty"`
+	}{
+		Issue2:   Issue2(issue),
+		ParentId: parentIssueID,
+	})
+}
+
 func getIssueFilterClause(filter *IssueFilter) string {
 	if filter == nil {
 		return ""


### PR DESCRIPTION
# Problem

Currently there's no way to reset the parent issue.

For example, when there are 2 issues, parent and child.
親子関係のチケットがあったとして

- parent [id=1]
  - child [id=2]

I tried to reset the parent of child[id=2] like below but couldn't.
子のチケットの親をリセット(id=1への所属を解除)したいですができません。

- parent [id=1]
- child [id=2]

My test code(not work):

```go
	client := redmine.NewClient("http://localhost:8080", "XXXXXXXXXXXXXXXXXXXXXXX")
	issue, _ := client.Issue(2)
	issue.ParentId = 0
	issue.Parent = nil
	client.UpdateIssue(*issue)
```

# Solution (API Usage)

To reset the parent, it seems that we must specify empty string `"parent_issue_id":""` explicitly.
リクエストボディのJSONのparent_issue_idに空文字を明示的に指定しなければならないようです。

```bash
curl -v -H "Content-Type:application/json" -XPUT localhost:8080/issues/2.json?key=XXXXXXXXXXXXXXXXXXXXXX -d '{"issue":{"id":30,"project":{"id":2,"name":"testproject2"},"tracker":{"id":1,"name":"Bug"},"status":{"id":1,"name":"New"},"priority":{"id":3,"name":"High"},"author":{"id":1,"name":"Redmine Admin"},"subject":"ticket2","description":"","start_date":"2018-07-23","due_date":"2018-07-25","done_ratio":0,"spent_hours":0.0,"total_spent_hours":0.0,"created_on":"2018-07-23T15:09:55Z","updated_on":"2018-07-24T11:36:47Z","parent_issue_id":""}}'
```

# Solution (Pull Request)

With this pull request, you can reset parent issue with `issue.Parent = nil`.

```go
	client := redmine.NewClient("http://localhost:8080", "XXXXXXXXXXXXXXXXXXXXXXX")
	issue, _ := client.Issue(2)
	issue.Parent = nil
	client.UpdateIssue(*issue)
```