### PR TITLE
Added the ability to set a assignee by ID

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -55,6 +55,7 @@ type Issue struct {
 	Author       *IdName        `json:"author"`
 	FixedVersion *IdName        `json:"fixed_version"`
 	AssignedTo   *IdName        `json:"assigned_to"`
+	AssignedToId int            `json:"assigned_to_id"`
 	Category     *IdName        `json:"category"`
 	CategoryId   int            `json:"category_id"`
 	Notes        string         `json:"notes"`


### PR DESCRIPTION
When creating an Issue, it is not possible to set the recipient if you use the AssignedTo property