### PR TITLE
enrich error on io.EOF error from json.decode for membership api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/mattn/go-redmine
 
 go 1.13
 
-require github.com/mattn/go-shellwords v1.0.12 // indirect
+require github.com/mattn/go-shellwords v1.0.12

--- a/membership.go
+++ b/membership.go
@@ -41,11 +41,7 @@ func (c *Client) Memberships(projectId int) ([]Membership, error) {
 		return nil, errors.New("Not Found")
 	}
 	if res.StatusCode != 200 {
-		var er errorsResult
-		err = decoder.Decode(&er)
-		if err == nil {
-			err = errors.New(strings.Join(er.Errors, "\n"))
-		}
+		err = errorFromResp(decoder, res.StatusCode)
 	} else {
 		err = decoder.Decode(&r)
 	}
@@ -68,11 +64,7 @@ func (c *Client) Membership(id int) (*Membership, error) {
 		return nil, errors.New("Not Found")
 	}
 	if res.StatusCode != 200 {
-		var er errorsResult
-		err = decoder.Decode(&er)
-		if err == nil {
-			err = errors.New(strings.Join(er.Errors, "\n"))
-		}
+		err = errorFromResp(decoder, res.StatusCode)
 	} else {
 		err = decoder.Decode(&r)
 	}
@@ -103,11 +95,7 @@ func (c *Client) CreateMembership(membership Membership) (*Membership, error) {
 	decoder := json.NewDecoder(res.Body)
 	var r membershipRequest
 	if res.StatusCode != 201 {
-		var er errorsResult
-		err = decoder.Decode(&er)
-		if err == nil {
-			err = errors.New(strings.Join(er.Errors, "\n"))
-		}
+		err = errorFromResp(decoder, res.StatusCode)
 	} else {
 		err = decoder.Decode(&r)
 	}
@@ -140,11 +128,7 @@ func (c *Client) UpdateMembership(membership Membership) error {
 	}
 	if res.StatusCode != 200 {
 		decoder := json.NewDecoder(res.Body)
-		var er errorsResult
-		err = decoder.Decode(&er)
-		if err == nil {
-			err = errors.New(strings.Join(er.Errors, "\n"))
-		}
+		err = errorFromResp(decoder, res.StatusCode)
 	}
 	if err != nil {
 		return err
@@ -170,11 +154,7 @@ func (c *Client) DeleteMembership(id int) error {
 
 	decoder := json.NewDecoder(res.Body)
 	if res.StatusCode != 200 {
-		var er errorsResult
-		err = decoder.Decode(&er)
-		if err == nil {
-			err = errors.New(strings.Join(er.Errors, "\n"))
-		}
+		err = errorFromResp(decoder, res.StatusCode)
 	}
 	return err
 }


### PR DESCRIPTION
On Redmine 5.0.4.stable, when we got a `403 Forbidden`(or other error status with empty http body, on memberships API) from redmine our error message is just a string `EOF`. That is not a clear message for go-redmine user. So here I return a new  created http TEXT status code string error when we got a EOF error from  json.Decode.