### PR TITLE
Fix response err for successful UpdateProject

### DIFF
--- a/issue_relations.go
+++ b/issue_relations.go
@@ -29,7 +29,7 @@ type IssueRelation struct {
 }
 
 func (c *Client) IssueRelations(issueId int) ([]IssueRelation, error) {
-	res, err := c.Get(c.endpoint + "/issue/" + strconv.Itoa(issueId) + "/relations.json?key=" + c.apikey + c.getPaginationClause())
+	res, err := c.Get(c.endpoint + "/issues/" + strconv.Itoa(issueId) + "/relations.json?key=" + c.apikey + c.getPaginationClause())
 	if err != nil {
 		return nil, err
 	}

--- a/issue_relations.go
+++ b/issue_relations.go
@@ -22,8 +22,8 @@ type issueRelationRequest struct {
 
 type IssueRelation struct {
 	Id           int    `json:"id"`
-	IssueId      string `json:"issue_id"`
-	IssueToId    string `json:"issue_to_id"`
+	IssueId      int    `json:"issue_id"`
+	IssueToId    int    `json:"issue_to_id"`
 	RelationType string `json:"relation_type"`
 	Delay        string `json:"delay"`
 }

--- a/project.go
+++ b/project.go
@@ -135,7 +135,7 @@ func (c *Client) UpdateProject(project Project) error {
 	if res.StatusCode == 404 {
 		return errors.New("Not Found")
 	}
-	if res.StatusCode != 200 {
+	if res.StatusCode != 200 && res.StatusCode != 204 {
 		decoder := json.NewDecoder(res.Body)
 		var er errorsResult
 		err = decoder.Decode(&er)


### PR DESCRIPTION
This pr is fixing false positive error being returned.

If project already exists and UpdateProject() is called client returns empty `err` (EOF). 

After debugging it and turns out redmine (6.0.2.) returns 204. Checked db and changes of project update indeed are present.
